### PR TITLE
fixed autobloat to run INSTALLME script completely

### DIFF
--- a/common/autobloat
+++ b/common/autobloat
@@ -34,7 +34,7 @@ echo `pwd`:
 	    fi
 	fi
 	aclocal || exit 1
-	if grep -q AM_CONFIG_HEADER configure.ac
+	if grep -q [AM\|AC]_CONFIG_HEADER configure.ac
 	then
 		autoheader || exit 1
 	fi
@@ -42,6 +42,11 @@ echo `pwd`:
 	then
 		sysconftoolize || exit 1
 	fi
+	for gitfile in $(find . -maxdepth 1 -name "*.in.git" -type f)
+	do
+		gitfile_dist=$(basename $gitfile ".git")
+		cp $gitfile $gitfile_dist
+	done
 	if test -f AUTHORS -a -f NEWS -a -f README
 	then
 		automake --add-missing || exit 1


### PR DESCRIPTION
Currently I cannot run INSTALLME script completely.
I changed autobloat script in two point to fix "required file 'XXXX' not found` error.

- added grep target newer autoheader macro `AC_CONFIG_HEADER`
- copied "XXXX.in.git" to "XXXX.in" file.

I got the following error before runnning INSTALLME script completely.

```
$ sh INSTALLME courier-imap/ https://github.com/svarshavchik/courier-libs.git
Cloning into 'libs'...

(.snip)

/home/mumumu/build/courier/courier-imap/libs/numlib:
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, '../..'.
libtoolize: copying file '../../ltmain.sh'
libtoolize: You should add the contents of the following files to 'aclocal.m4':
libtoolize:   '/usr/share/aclocal/libtool.m4'
libtoolize:   '/usr/share/aclocal/ltoptions.m4'
libtoolize:   '/usr/share/aclocal/ltsugar.m4'
libtoolize:   '/usr/share/aclocal/ltversion.m4'
libtoolize:   '/usr/share/aclocal/lt~obsolete.m4'
libtoolize: Consider adding 'AC_CONFIG_MACRO_DIRS([m4])' to configure.ac,
libtoolize: and rerunning libtoolize and aclocal.
libtoolize: Consider adding '-I m4' to ACLOCAL_AMFkLAGS in Makefile.am.
configure.ac:18: installing '../../compile'
configure.ac:14: installing '../../missing'
configure.ac:13: error: required file 'config.h.in' not found
```
```
sh INSTALLME courier-imap/ https://github.com/svarshavchik/courier-libs.git
Cloning into 'libs'...

(.snip)

/home/mumumu/build/courier/courier-imap/libs/imap:
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, '../..'.
libtoolize: copying file '../../ltmain.sh'
libtoolize: You should add the contents of the following files to 'aclocal.m4':
libtoolize:   '/usr/share/aclocal/libtool.m4'
libtoolize:   '/usr/share/aclocal/ltoptions.m4'
libtoolize:   '/usr/share/aclocal/ltsugar.m4'
libtoolize:   '/usr/share/aclocal/ltversion.m4'
libtoolize:   '/usr/share/aclocal/lt~obsolete.m4'
libtoolize: Consider adding 'AC_CONFIG_MACRO_DIRS([m4])' to configure.ac,
libtoolize: and rerunning libtoolize and aclocal.
libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am.
configure.ac:19: installing '../../compile'
configure.ac:14: installing '../../missing'
configure.ac:380: error: required file 'imapd.dist.in' not found
configure.ac:380: error: required file 'imapd-ssl.dist.in' not found
configure.ac:380: error: required file 'pop3d.dist.in' not found
configure.ac:380: error: required file 'pop3d-ssl.dist.in' not found
```