### PR TITLE
imap: Allow to override build date

### DIFF
--- a/imap/configure.ac
+++ b/imap/configure.ac
@@ -341,7 +341,8 @@ courier)
 	;;
 esac
 
-date=`date`
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-`date +%s`}"
+date=`date -u -d "@$SOURCE_DATE_EPOCH" "+%F %T" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" "+%F %T" 2>/dev/null || date -u "+%F %T"`
 AC_DEFINE_UNQUOTED(PROGRAMVERSION, "$package/${target_cpu}-${target_vendor}-${target_os}/$date",
 		       [ Source code version ])
 


### PR DESCRIPTION
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call works with various variants of date (incl GNU and BSD).

Without this patch, the courier-imap openSUSE Linux package varied for each build.

See also
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=824037