### PR TITLE
libgcrypt is required when --with-gnutls specified explicitly

### DIFF
--- a/tcpd/configure.ac
+++ b/tcpd/configure.ac
@@ -459,8 +459,13 @@ then
 	CRYPTLIBS="$CRYPTLIBS -lgcrypt"
 ], [
 AC_MSG_RESULT(no)
+have_gcrypt="no"
 ])
 
+	if test "$have_gcrypt" = "no"
+	then
+		AC_MSG_ERROR(gcrypt header file is required for GNUTLS)
+	fi
 	AC_MSG_CHECKING([for libgpg-error])
 	LIBS="$LIBS -lgpg-error"
 	AC_TRY_LINK( [


### PR DESCRIPTION
We must use `--with-gnutls` option to select explicitly the GnuTLS library over OpenSSL.
Currently if we specify `--with-gnutls` option and libgcrypt header file is not installed, we will have the following error.

```
(... we assume courier-authlib is already installed on /home/mumumu/local )

$ sh INSTALLME courier-imap https://github.com/svarshavchik/courier-libs.git
$ cd courier-imap
$ COURIERAUTHCONFIG=/home/mumumu/local/bin/courierauthconfig CFLAGS=-I/home/mumumu/local/include ./configure --prefix=/home/mumumu/local/ --with-gnutls
$ make -j8

(.snip)

/bin/bash ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.   -I/usr/include/p11-kit-1  -I./.. -I.. -I./../.. -I../.. -Wall -I/home/mumumu/local/include -MT tlspasswordcache.lo -MD -MP -MF .deps/tlspasswordcache.Tpo -c -o tlspasswordcache.lo tlspasswordcache.c

mv -f .deps/tcpdaccess.Tpo .deps/tcpdaccess.Po
tlspasswordcache.c:366:9: error: unknown type name ‘EVP_CIPHER_CTX’
 typedef EVP_CIPHER_CTX CIPHER_CONTEXT;
         ^~~~~~~~~~~~~~
Makefile:577: recipe for target 'tlspasswordcache.lo' failed
make[3]: *** [tlspasswordcache.lo] Error 1
```

Yes, libgcrypt is required when `--with-gnutls` option specified explicitly, but this fact is not forced by configure script, we should change configure.ac to enforce its requirement.