### PR TITLE
added comment TLS_PRIVATE_KEYFILE does not support Pass-Phrase

### DIFF
--- a/imap/imapd-ssl.dist.in.git
+++ b/imap/imapd-ssl.dist.in.git
@@ -233,7 +233,8 @@ TLS_CERTFILE=@certsdir@/imapd.pem
 #
 # TLS_PRIVATE_KEYFILE - SSL/TLS private key for decrypting peer data.
 # This file must be owned by the "@mailuser@" user, and must not be world
-# readable.
+# readable, and must be accessible without a pass-phrase, i.e. it must not
+# be encrypted.
 #
 # By default, courier generates SSL/TLS certifice including private key
 # and install it in TLS_CERTFILE path, so TLS_PRIVATE_KEYFILE is completely

--- a/imap/pop3d-ssl.dist.in.git
+++ b/imap/pop3d-ssl.dist.in.git
@@ -227,7 +227,8 @@ TLS_CERTFILE=@certsdir@/pop3d.pem
 #
 # TLS_PRIVATE_KEYFILE - SSL/TLS private key for decrypting peer data.
 # This file must be owned by the "@mailuser@" user, and must not be world
-# readable.
+# readable, and must be accessible without a pass-phrase, i.e. it must not
+# be encrypted.
 #
 # By default, courier generates SSL/TLS certifice including private key
 # and install it in TLS_CERTFILE path, so TLS_PRIVATE_KEYFILE is completely

--- a/tcpd/couriertls.sgml
+++ b/tcpd/couriertls.sgml
@@ -241,7 +241,7 @@ for SSL/TLS clients.
 	  <para>
 SSL/TLS private key for decrypting client data.
 <envar>TLS_PRIVATE_KEY</envar> is optional because <term>TLS_CERTFILE</term> is generated including cert and private key both.
-<replaceable>filename</replaceable> must not be world-readable.</para>
+<replaceable>filename</replaceable> must not be world-readable, and must be accessible without a pass-phrase, i.e. it must not be encrypted.</para>
 	</listitem>
       </varlistentry>
 


### PR DESCRIPTION
We added `TLS_PRIVATE_KEYFILE` feature on #13, but I forgot commenting the important fact that it does not support encryption by Pass-Phrase, so added comment here.