### PR TITLE
fix ssl client cert authentication (EXTERNAL)

### DIFF
--- a/tcpd/starttls.c
+++ b/tcpd/starttls.c
@@ -542,8 +542,6 @@ static int dossl(int fd, int argn, int argc, char **argv)
 	stdin_fd=0;
 	stdout_fd=1;
 
-	startclient(argn, argc, argv, fd, &stdin_fd, &stdout_fd);
-
 	if (username)
 		libmail_changeusername(username, 0);
 
@@ -565,6 +563,8 @@ static int dossl(int fd, int argn, int argc, char **argv)
 		tls_destroy(ctx);
 		return 1;
 	}
+
+	startclient(argn, argc, argv, fd, &stdin_fd, &stdout_fd);
 
 	docopy(ssl, fd, stdin_fd, stdout_fd);
 


### PR DESCRIPTION
The connect_callback verify_connection does setenv(TLS_SUBJECT_*) by calling dump_to_fp.  These Environment variables are needed to do "AUTHENTICATE EXTERNAL" by doing a user lookup with one of the TLS_SUBJECT_* Variables (specified in the config file via TLS_EXTERNAL). 

If we call startclient() after the ssl connection has established, we actually do the fork()/exec with the updated environment and thus imapdlogin can do authentication. 

This error was not producing any error messages besides LOGIN FAILED.  :(

With this change, i was able to connect with openssl s_client, run "AUTHENTICATE EXTERNAL" and have a successfull login. No further testing was done.