### PR TITLE
Adding special TLS protocol names that disable client renegotiation.

### DIFF
--- a/imap/imapd-ssl.dist.in.git
+++ b/imap/imapd-ssl.dist.in.git
@@ -138,7 +138,9 @@ COURIERTLS=@bindir@/couriertls
 #
 # TLSv1 - TLS 1.0, or higher.
 # TLSv1.1 - TLS1.1, or higher.
+# TLSv1.1++ TLS1.1, or higher, without client-initiated renegotiation.
 # TLSv1.2 - TLS1.2, or higher.
+# TLSv1.2++ TLS1.2, or higher, without client-initiated renegotiation.
 #
 # The default value is TLSv1
 

--- a/imap/pop3d-ssl.dist.in.git
+++ b/imap/pop3d-ssl.dist.in.git
@@ -125,7 +125,9 @@ COURIERTLS=@bindir@/couriertls
 #
 # TLSv1 - TLS 1.0, or higher.
 # TLSv1.1 - TLS1.1, or higher.
+# TLSv1.1++ TLS1.1, or higher, without client-initiated renegotiation.
 # TLSv1.2 - TLS1.2, or higher.
+# TLSv1.2++ TLS1.2, or higher, without client-initiated renegotiation.
 #
 # The default value is TLSv1.
 

--- a/tcpd/libcouriertls.c
+++ b/tcpd/libcouriertls.c
@@ -66,12 +66,14 @@ struct proto_ops op_list[] =
 {
 #ifdef SSL_OP_NO_TLSv1
 #ifdef SSL_OP_NO_TLSv1_1
+    { "TLSv1.2++", &SSLv23_method,  SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1|SSL_OP_NO_RENEGOTIATION },
     { "TLSv1.2+",  &SSLv23_method,  SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1 },
     { "TLSv1.2",   &SSLv23_method,  SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_TLSv1_1 },
 #endif
 #endif
 
 #ifdef SSL_OP_NO_TLSv1
+    { "TLSv1.1++", &SSLv23_method,  SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1|SSL_OP_NO_RENEGOTIATION },
     { "TLSv1.1+",  &SSLv23_method,  SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1 },
     { "TLSv1.1",   &SSLv23_method,  SSL_OP_ALL|SSL_OP_NO_SSLv2|SSL_OP_NO_SSLv3|SSL_OP_NO_TLSv1 },
 #endif


### PR DESCRIPTION
I've checked that this hack addresses svarshavchik/courier#23. (Unfortunately I don't have time to play with the GnuTLS side of things.)

The `++` naming is ugly and used just for the lack of a better idea. (While a single `+` is no longer used in its original sense and looked like a good candidate, reusing it might break backward compatibility with old configs.)

Anyway, the main purpose of the PR is to identify the OpenSSL flag for the record.