### PR TITLE
TLS_CACHEFILE filenames swapped

### DIFF
--- a/imap/imapd-ssl.dist.in.git
+++ b/imap/imapd-ssl.dist.in.git
@@ -313,7 +313,7 @@ TLS_VERIFYPEER=NONE
 # automatically created, TLS_CACHESIZE bytes long, and used as a cache
 # buffer.
 
-TLS_CACHEFILE=@localstatedir@/couriersslpop3cache
+TLS_CACHEFILE=@localstatedir@/couriersslimapcache
 TLS_CACHESIZE=524288
 
 ##NAME: TLS_ALPN:0

--- a/imap/pop3d-ssl.dist.in.git
+++ b/imap/pop3d-ssl.dist.in.git
@@ -310,7 +310,7 @@ TLS_VERIFYPEER=NONE
 # problems with SSL clients.  Disable SSL caching by commenting out the
 # following settings:
 
-TLS_CACHEFILE=@localstatedir@/couriersslimapcache
+TLS_CACHEFILE=@localstatedir@/couriersslpop3cache
 TLS_CACHESIZE=524288
 
 ##NAME: TLS_ALPN:0


### PR DESCRIPTION
The TLS_CACHEFILE name is swapped for the `imapd-ssl.dist.in.git` and `pop3d-ssl.dist.in.git` files