### PR TITLE
Various fixes for calls to getgrnam_r/getpwnam_r

### DIFF
--- a/numlib/changeuidgid.c
+++ b/numlib/changeuidgid.c
@@ -95,7 +95,7 @@ uid_t libmail_getuid(const char *uname, gid_t *pw_gid)
 	if (pw == 0)
 	{
 		free(p);
-		perror("getpwnam");
+		perror("getpwnam_r");
 		exit(1);
 	}
 	free(p);
@@ -187,7 +187,7 @@ gid_t libmail_getgid(const char *gname)
 		else
 		{
 			errno = s;
-			perror("getpwnam_r");
+			perror("getgrnam_r");
 		}
 		exit(1);
 	}

--- a/numlib/changeuidgid.c
+++ b/numlib/changeuidgid.c
@@ -52,7 +52,7 @@ void libmail_changeuidgid(uid_t uid, gid_t gid)
  */
 uid_t libmail_getuid(const char *uname, gid_t *pw_gid)
 {
-	size_t bufsize;
+	int bufsize;
 	char *buf;
 	struct passwd pwbuf;
 	struct passwd *pw;
@@ -149,7 +149,7 @@ gid_t libmail_getgid(const char *gname)
 	struct group grp;
 	struct group *result;
 	char *buf;
-	size_t bufsize;
+	int bufsize;
 	int s;
 	char	*p=malloc(strlen(gname)+1);
 

--- a/numlib/changeuidgid.c
+++ b/numlib/changeuidgid.c
@@ -73,8 +73,8 @@ uid_t libmail_getuid(const char *uname, gid_t *pw_gid)
 #ifdef _SC_GETPW_R_SIZE_MAX
 	bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
 	if (bufsize == -1)          /* Value was indeterminate */
-	{
 #endif
+	{
 		bufsize = 16384;        /* Should be more than enough */
 	}
 

--- a/numlib/changeuidgid.c
+++ b/numlib/changeuidgid.c
@@ -70,8 +70,8 @@ uid_t libmail_getuid(const char *uname, gid_t *pw_gid)
 	}
 	strcpy(p, uname);
 
-#ifdef _SC_GETGR_R_SIZE_MAX
-	bufsize = sysconf(_SC_GETGR_R_SIZE_MAX);
+#ifdef _SC_GETPW_R_SIZE_MAX
+	bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
 	if (bufsize == -1)          /* Value was indeterminate */
 	{
 #endif


### PR DESCRIPTION
See also discussion on mailing list:
https://marc.info/?l=courier-users&m=167707269025424&w=2

This should hopefully fix all issues and also avoid the mistakes I had in the first patch (double free, missing errno setting).