### PR TITLE
If a client explicitly connects to a TLS port, that should satisfy the

### DIFF
--- a/imap/capability.c
+++ b/imap/capability.c
@@ -44,8 +44,12 @@ int tlsrequired()
 {
 const char *p=getenv("IMAP_TLS_REQUIRED");
 
-	if (p && atoi(p))       return (1);
-	return (0);
+	if (!p || !atoi(p))	return(0);
+
+	p=getenv("IMAP_TLS");
+	if (p && atoi(p))       return (0);
+
+	return (1);
 }
 
 int keywords()

--- a/imap/pop3dcapa.c
+++ b/imap/pop3dcapa.c
@@ -38,9 +38,12 @@ int have_starttls()
 int tls_required()
 {
 	const char *p=getenv("POP3_TLS_REQUIRED");
+	if (!p || !atoi(p))	return(0);
 
-        if (p && atoi(p))       return (1);
-        return (0);
+	p=getenv("POP3_TLS");
+	if (p && atoi(p))       return (0);
+
+	return (1);
 }
 
 const char *pop3_externalauth()


### PR DESCRIPTION
*_TLS_REQUIRED configuration options.