### PR TITLE
pop3+imap: log stls=1 (pop3) and starttls=1 (imap) on LOGIN lines.

### DIFF
--- a/imap/imapd.c
+++ b/imap/imapd.c
@@ -6661,9 +6661,10 @@ static void chkdisabled(const char *ip, const char *port)
 		exit(0);
 	}
 
-	fprintf(stderr, "INFO: LOGIN, user=%s, ip=[%s], port=[%s], protocol=%s\n",
+	fprintf(stderr, "INFO: LOGIN, user=%s, ip=[%s], port=[%s], protocol=%s%s\n",
 		getenv("AUTHENTICATED"), ip, port,
-		protocol);
+		protocol,
+		(p=getenv("IMAP_TLS")) != 0 && atoi(p) ? ", starttls=1" : "");
 }
 
 static int chk_clock_skew()

--- a/imap/imaplogin.c
+++ b/imap/imaplogin.c
@@ -208,10 +208,11 @@ int login_callback(struct authinfo *ainfo, void *dummy)
 			{
 				alarm(0);
 
-				fprintf(stderr, "INFO: LOGIN, user=%s, ip=[%s], port=[%s], protocol=%s\n",
+				fprintf(stderr, "INFO: LOGIN, user=%s, ip=[%s], port=[%s], protocol=%s%s\n",
 					ainfo->address, safe_getenv("TCPREMOTEIP"),
 					safe_getenv("TCPREMOTEPORT"),
-					safe_getenv("PROTOCOL"));
+					safe_getenv("PROTOCOL"),
+					(p=getenv("IMAP_TLS")) != 0 && atoi(p) ? ", starttls=1" : "");
 
 				proxyloop(fd);
 				exit(0);

--- a/imap/pop3dserver.c
+++ b/imap/pop3dserver.c
@@ -1197,10 +1197,11 @@ char	*p;
 		exit(1);
 	}
 
-	fprintf(stderr, "INFO: LOGIN, user=%s, ip=[%s], port=[%s]\n",
+	fprintf(stderr, "INFO: LOGIN, user=%s, ip=[%s], port=[%s]%s\n",
 			authaddr,
 					remoteip,
-					remoteport);
+					remoteport,
+					(p=getenv("POP3_TLS")) != 0 && atoi(p) ? ", stls=1" : "");
 	fflush(stderr);
 
 	msglist_cnt=0;

--- a/imap/pop3login.c
+++ b/imap/pop3login.c
@@ -247,10 +247,11 @@ static int login_callback(struct authinfo *ainfo, void *dummy)
 			if (fd > 0)
 			{
 				alarm(0);
-				fprintf(stderr, "INFO: LOGIN, user=%s, ip=[%s], port=[%s], protocol=%s\n",
+				fprintf(stderr, "INFO: LOGIN, user=%s, ip=[%s], port=[%s], protocol=%s%s\n",
 					ainfo->address, safe_getenv("TCPREMOTEIP"),
 					safe_getenv("TCPREMOTEPORT"),
-					safe_getenv("PROTOCOL"));
+					safe_getenv("PROTOCOL"),
+					(p=getenv("POP3_TLS")) != 0 && atoi(p) ? ", stls=1" : "");
 
 				proxyloop(fd);
 				exit(0);


### PR DESCRIPTION
Sample log lines with this patch, making it possible to differentiate on the LOGIN lines whether or not the connection was secured:

pop3d: LOGIN, user=testuser, ip=[::1], port=[60886]
pop3d: LOGIN, user=testuser, ip=[::1], port=[60888], stls=1
pop3d-ssl: LOGIN, user=testuser, ip=[::1], port=[55880], stls=1
imapd: LOGIN, user=testuser, ip=[::1], port=[42328], protocol=IMAP
imapd: LOGIN, user=testuser, ip=[::1], port=[42332], protocol=IMAP, starttls=1
imapd-ssl: LOGIN, user=testuser, ip=[::1], port=[45792], protocol=IMAP, starttls=1

In the -ssl cals stls=1 and starttls=1 will always be output (same as on LOGOUT lines).  This is because I cannot find a way to differentiate between starttls and explicit ssl/tls port connections.