### PR TITLE
Make the SqWebMail agruments configurable in /etc/courier/sqwebmaild.

### DIFF
--- a/sqwebmail/sendit.sh.in
+++ b/sqwebmail/sendit.sh.in
@@ -21,6 +21,16 @@
 # You may modify the message in whatever fashion before passing it on to the
 # MTA.
 #
-# exec /usr/sbin/sendmail -oi -t -f "$1"
+# The SENDMAIL_ARGUMENTS can be set in /etc/courier/sqwebmaild.
 
-exec @mailer@ $DSN -f "$1"
+# Check to see if the SENDMAIL_ARGUMENTS variable is set in
+# /etc/courier/sqwebmaild.
+if [ -n "$SENDMAIL_ARGUMENTS" ] ; then
+    # The exec command is prepended with eval so that SENDMAIL_ARGUMENTS are
+    # correctly expanded.
+    eval exec @mailer@ $SENDMAIL_ARGUMENTS
+else
+    # Run the default command that works with Courier if nothing is set in
+    # /etc/courier/sqwebmaild.
+    exec @mailer@ $DSN -f "$1"
+fi

--- a/sqwebmail/sqwebmaild.dist.in.git
+++ b/sqwebmail/sqwebmaild.dist.in.git
@@ -5,7 +5,7 @@
 # Do not alter lines that begin with ##, they are used when upgrading
 # this configuration.
 #
-#  Copyright 2004-2005 Double Precision, Inc.  See COPYING for
+#  Copyright 2004-2005, 2025 Double Precision, Inc.  See COPYING for
 #  distribution information.
 #
 #  Courier sqwebmaild daemon configuration
@@ -81,3 +81,16 @@ LOGGEROPTS=""
 # Each occurence of @ is replaced by the search key
 #
 # You may provide your own settings below.
+
+##NAME: SENDMAIL_ARGUMENTS:0
+#
+# Specify the arguments SqWebMail passes to sendmail.
+#
+# The default is '$DSN -f "$1"', which works well with Courier.  However, other
+# MTAs may require different arguments.
+#
+# The following is known to work with Exim and Postfix:
+#
+# SENDMAIL_ARGUMENTS='-oi -t -f "$1"'
+
+SENDMAIL_ARGUMENTS='$DSN -f "$1"'


### PR DESCRIPTION
I believe this is a minimally invasive change that allows the sendmail arguments to be set in /etc/courier/sqwebmaild.

I have tested this on my SqWebMail instance, but it would be good to have a more experienced pair of eyes take a look to make sure I haven't made a syntax mistake that could cause problems in other setups.

I assign my copyright interests in the code to Double Precision, Inc. and have updated the copyright statement accordingly.