### PR TITLE
Add CRAM documentation URL to imapd.dist.in.git.

### DIFF
--- a/imap/imapd.dist.in.git
+++ b/imap/imapd.dist.in.git
@@ -106,7 +106,9 @@ LOGGEROPTS="-name=imapd"
 # CAPABILITY command.
 #
 # If you have properly configured Courier to use CRAM-MD5, CRAM-SHA1, or
-# CRAM-SHA256 authentication (see INSTALL), set IMAP_CAPABILITY as follows:
+# CRAM-SHA256 authentication (see
+# https://www.courier-mta.org/imap/INSTALL.html#crammd5), set IMAP_CAPABILITY
+# as follows:
 #
 # IMAP_CAPABILITY="IMAP4rev1 UIDPLUS CHILDREN NAMESPACE THREAD=ORDEREDSUBJECT THREAD=REFERENCES SORT QUOTA AUTH=CRAM-MD5 AUTH=CRAM-SHA1 AUTH=CRAM-SHA256 IDLE"
 #


### PR DESCRIPTION
This resolves discussion in https://github.com/svarshavchik/courier-libs/issues/44.