### PR TITLE
Fix DH_BITS type in mkdhparams documentation.

### DIFF
--- a/imap/mkdhparams.sgml
+++ b/imap/mkdhparams.sgml
@@ -58,7 +58,7 @@
 
     <variablelist>
       <varlistentry>
-	<term>BITS</term>
+	<term>DH_BITS</term>
 	<listitem>
 	  <simpara>
 	    Customize the DH parameter bit size. The default value depends on


### PR DESCRIPTION
The mkdhparams documentation has a typo where the `DH_BITS` variable is incorrectly listed as `BITS`.  This PR updates the documentation to match the variable name at:

https://github.com/svarshavchik/courier-libs/blob/master/imap/mkdhparams.in#L42

For reference, see the following two Debian bug reports:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=828920
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=793184