### PR TITLE
reformime: fix sanitization of -x option

### DIFF
--- a/rfc2045/reformime.C
+++ b/rfc2045/reformime.C
@@ -342,14 +342,15 @@ std::string get_suitable_filename(const rfc2045::entity &message,
 			       filename.begin()+2);	/* Skip over ./ */
 	}
 
-	filename.insert(filename.begin(), pfix.begin(), pfix.end());
-
 	for (char &c:filename)
 	{
 		unsigned char d=c;
 		if (!isalnum(d) && d != '.' && d != '-' && d != '=')
 			c='_';
 	}
+
+	filename.insert(filename.begin(), pfix.begin(), pfix.end());
+
 	if (pfix.size() == 0)
 	{
 		std::fstream tty{"/dev/tty"};


### PR DESCRIPTION
the filename prefix specified in -x option was unintentionally sanitized instead of just the filename coming from MIME header.