### PR TITLE
Fix some typos in the source code

### DIFF
--- a/maildir/maildiraclt.h
+++ b/maildir/maildiraclt.h
@@ -95,7 +95,7 @@ struct aclt_list : std::vector<aclt_node> {
 	**
 	** The closure should return >0 if identifier refers to the entity
 	** whose access rights are to be computed; 0 if it does not, <0 if
-	** an error occured.
+	** an error occurred.
 	**
 	** As a special case,compute() handles "anonymous" and "anyone"
 	** identifiers on its own.

--- a/maildir/maildirkeywords.C
+++ b/maildir/maildirkeywords.C
@@ -681,7 +681,7 @@ static bool attempt_load(
 		    rename(tmpname.c_str(),
 			   (keyworddir + "/:list").c_str()) < 0)
 			throw std::runtime_error(
-				"An error occured while sving keywords");
+				"An error occurred while sving keywords");
 	}
 
 	cleanup(d, statuses, t, tn);

--- a/rfc2045/rfc2045.h
+++ b/rfc2045/rfc2045.h
@@ -1090,7 +1090,7 @@ auto rfc2231_attr_encode(std::string_view name,
 
   The iterators must be passed by reference. parse() updates them, and normally
   the beginning iterator gets advanced to the ending iterator, unless a fatal
-  parsing error occured.
+  parsing error occurred.
 
   The iter class is a template, and the template parameters should get deduced
   from the constructor's parameters. Older C++17 compilers may not fully

--- a/rfc2045/rfc2045reply.h
+++ b/rfc2045/rfc2045reply.h
@@ -561,7 +561,7 @@ void rfc2045::reply::reformat(out_closure_t &&out_closure,
 		}
 	}
 
-	out_closure("\n[ A character set conversion error has occured]\n");
+	out_closure("\n[ A character set conversion error has occurred]\n");
 }
 
 // forward/forwardatt autoreplies


### PR DESCRIPTION
Hi, I'm helping with maintaining `maildrop` in Debian and I found these typos using Lintian.